### PR TITLE
score, ammo, bugs

### DIFF
--- a/Assets/ExplodingBarrel.cs
+++ b/Assets/ExplodingBarrel.cs
@@ -9,7 +9,15 @@ public class ExplodingBarrel : MonoBehaviour
     [SerializeField] int damage = 15;
     [SerializeField] ParticleSystem explosionEffect;
 
+    private HUDHandler hudHandler;
+    private bool scoreOnce = false;
+
     private bool isTriggered = false;
+
+    private void Awake()
+    {
+        hudHandler = FindFirstObjectByType<HUDHandler>();
+    }
 
     public void TakeDamage()
     {
@@ -18,6 +26,8 @@ public class ExplodingBarrel : MonoBehaviour
             isTriggered = true;
             Invoke(nameof(Explode), delay);
         }
+
+      
     }
 
     void Explode()
@@ -64,10 +74,16 @@ public class ExplodingBarrel : MonoBehaviour
             if (nearby.TryGetComponent(out ExplodingBarrel otherBarrel) && otherBarrel != this)
             {
                 otherBarrel.TakeDamage();
-            }
+            } 
         }
 
-
         Destroy(gameObject);
+
+        //give score to hud
+        if (hudHandler != null && !scoreOnce)
+        {
+            scoreOnce = true;
+            hudHandler.addScore(500);
+        }
     }
 }

--- a/Assets/Scenes/Test day 1.unity
+++ b/Assets/Scenes/Test day 1.unity
@@ -3541,6 +3541,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Toggle keycardNotification
       objectReference: {fileID: 0}
+    - target: {fileID: 1556447073908508586, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: UIHandler
+      value: 
+      objectReference: {fileID: 1656261821}
     - target: {fileID: 1950277813784723794, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -3625,13 +3629,17 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2819897760910025248, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 239
+      objectReference: {fileID: 0}
     - target: {fileID: 3714470230937302724, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3714470230937302724, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3810117488595815058, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -3697,9 +3705,49 @@ PrefabInstance:
       propertyPath: toggleHUDKeycard
       value: 
       objectReference: {fileID: 687594490}
+    - target: {fileID: 4924959772579200127, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 268
+      objectReference: {fileID: 0}
+    - target: {fileID: 5240740638856196061, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_text
+      value: Placeholder - find the keycard
+      objectReference: {fileID: 0}
+    - target: {fileID: 5240740638856196061, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_fontSize
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 5240740638856196061, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_fontColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5240740638856196061, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_fontColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5240740638856196061, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_fontColor.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5240740638856196061, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_fontSizeBase
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 5240740638856196061, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294506744
+      objectReference: {fileID: 0}
     - target: {fileID: 5570825709975296356, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5802696248414974632, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8260900835646778339, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8633118210201857588, guid: 77c280a2788495c48a266b2a90dfce48, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scripts/Enemy/CheckIfEnemyDead.cs
+++ b/Assets/Scripts/Enemy/CheckIfEnemyDead.cs
@@ -8,7 +8,9 @@ public class CheckIfEnemyDead : MonoBehaviour
     [SerializeField] EnemyMove enemyMove;
     [SerializeField] EnemyShoot enemyShoot;
     [SerializeField] EnemyWeaponInventory enemyWeaponInventory;
+    
     private HUDHandler hudHandler; 
+    private bool scoreOnce = false;
 
     [SerializeField] GameObject hitboxObject;
     //references
@@ -30,8 +32,9 @@ public class CheckIfEnemyDead : MonoBehaviour
         ragDollController.BecomeRagDoll();
         StartCoroutine(DestroyGameObject());
 
-        if (hudHandler != null)
+        if (hudHandler != null && !scoreOnce)
         {
+            scoreOnce = true;
             hudHandler.addMoney(3);
             hudHandler.addScore(150);
         }

--- a/Assets/Scripts/Player/PlayerHealth.cs
+++ b/Assets/Scripts/Player/PlayerHealth.cs
@@ -16,6 +16,7 @@ public class PlayerHealth : MonoBehaviour
         hudHandler.setHealth(health);
     }
 
+
     public void ApplyDamage(int damage)
     {
         health -= damage/4;

--- a/Assets/Scripts/Shooting/PlayerShoot.cs
+++ b/Assets/Scripts/Shooting/PlayerShoot.cs
@@ -8,7 +8,9 @@ public class PlayerShoot : MonoBehaviour
 {
     [SerializeField] Shoot shootScript;
     [SerializeField] EquipWeapon equipWeapon;
+
     [SerializeField] HUDHandler hudHandler;
+    private bool reloadMessageShown = false;
     //SoundEffectsPlayer SEP;
 
     WeaponData weaponData;
@@ -74,6 +76,7 @@ public class PlayerShoot : MonoBehaviour
         weaponScript.ReloadBullets();
         isReloading = false;
         isReadyToShoot = true;
+        reloadMessageShown = false;
     }
 
     void Shoot()
@@ -154,6 +157,12 @@ public class PlayerShoot : MonoBehaviour
                 isShooting = false;
                 //SEP.getShooting();
             }
+        }
+
+        if (weaponScript.bulletsLeft == 0 && !reloadMessageShown)
+        {
+            reloadMessageShown = true;
+            hudHandler.setAnnounchment("Reload with R", 3);
         }
     }
 }

--- a/Assets/Scripts/UI/HUDHandler.cs
+++ b/Assets/Scripts/UI/HUDHandler.cs
@@ -3,6 +3,8 @@ using FirstGearGames.SmoothCameraShaker;
 
 public class HUDHandler : MonoBehaviour
 {
+    [SerializeField] UIHandler UIHandler;
+
     private TimerUIScript timerUIScript;
     private Money moneyScript;
     private HealthBar healthBarScript;
@@ -113,7 +115,9 @@ public class HUDHandler : MonoBehaviour
 
     public void setMaxHealth(float health)
     {
+        UIHandler.ToggleHUD();
         healthBarScript.setMaxHealth(health);
+        UIHandler.ToggleHUD();
     }
 
     public void addHealth(float addHealth)
@@ -215,5 +219,11 @@ public class HUDHandler : MonoBehaviour
     public void FimShootingShake()
     {
         CameraShakerHandler.Shake(shootShake);
+    }
+
+    //menu bool
+    public bool isMenuActive()
+    {
+        return UIHandler.isMenuActive();
     }
 }

--- a/Assets/Scripts/UI/UIHandler.cs
+++ b/Assets/Scripts/UI/UIHandler.cs
@@ -141,4 +141,9 @@ public class UIHandler : MonoBehaviour
     {
         Time.timeScale = 1f;
     }
+
+    public bool isMenuActive()
+    {
+        return UI.activeSelf;
+    }
 }


### PR DESCRIPTION
* You now get score by exploding barrels (does't always work is the first map for some reason, but if you regenreate the map it works????)
* fixed a bug where you could get huge score and money by killing enemys with barrels
* fixed errors cause by HUDHandler trying to set max HP while HUD not being active
* Added an announcement that lasts for 3s when you're out of ammo reminding the player of what buttons is reload (can be shown again after the player has reloaded)
* Added a way to see if the menu is active in HUDHandler, meant for the sound so certain sounds dont play in the menu